### PR TITLE
(docs): add gatsby-plugin-svgr to plugins list

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -142,6 +142,7 @@ root.
 * [gatsby-plugin-segment-js](https://github.com/benjaminhoffman/gatsby-plugin-segment-js)
 * [gatsby-plugin-stripe-checkout](https://github.com/njosefbeck/gatsby-plugin-stripe-checkout)
 * [gatsby-plugin-stripe-elements](https://github.com/njosefbeck/gatsby-plugin-stripe-elements)
+* [gatsby-plugin-svgr](https://github.com/zabute/gatsby-plugin-svgr)
 * [gatsby-plugin-yandex-metrika](https://github.com/viatsko/gatsby-plugin-yandex-metrika)
 * [gatsby-remark-emoji](https://github.com/Rulikkk/gatsby-remark-emoji)
 * [gatsby-remark-external-links](https://github.com/JLongley/gatsby-remark-external-links)


### PR DESCRIPTION
This plugin replaces ```url-loader``` for svg files with  [svgr](https://github.com/smooth-code/svgr) 's loader, which automatically transforms svg files to react components for you. 